### PR TITLE
【Fixed】詳細表示機能、編集機能の実装

### DIFF
--- a/app/assets/stylesheets/props.scss
+++ b/app/assets/stylesheets/props.scss
@@ -5,3 +5,8 @@
 .properties {
   padding-top: 70px;
 }
+
+.show_label {
+  font-weight: bold;
+  padding-right: 20px;
+}

--- a/app/controllers/props_controller.rb
+++ b/app/controllers/props_controller.rb
@@ -17,6 +17,10 @@ class PropsController < ApplicationController
     end
   end
 
+  def show
+    @prop = Prop.find(params[:id])
+  end
+
   private
 
   def prop_params

--- a/app/controllers/props_controller.rb
+++ b/app/controllers/props_controller.rb
@@ -26,8 +26,10 @@ class PropsController < ApplicationController
   end
 
   def update
+    @prop = Prop.find(params[:id])
     if @prop.update(prop_params)
-      redirect_to props_path, flash[:notice] = "物件を編集しました。"
+      redirect_to props_path
+      flash[:notice] = "物件を編集しました。"
     else
       render :edit
     end

--- a/app/controllers/props_controller.rb
+++ b/app/controllers/props_controller.rb
@@ -21,6 +21,18 @@ class PropsController < ApplicationController
     @prop = Prop.find(params[:id])
   end
 
+  def edit
+    @prop = Prop.find(params[:id])
+  end
+
+  def update
+    if @prop.update(prop_params)
+      redirect_to props_path, flash[:notice] = "物件を編集しました。"
+    else
+      render :edit
+    end
+  end
+
   private
 
   def prop_params

--- a/app/helpers/props_helper.rb
+++ b/app/helpers/props_helper.rb
@@ -1,2 +1,7 @@
 module PropsHelper
+  def presence_or_not_display(data)
+    if data
+      data
+    end
+  end
 end

--- a/app/views/props/_form.html.erb
+++ b/app/views/props/_form.html.erb
@@ -1,4 +1,3 @@
-<%= render "form" %>
 <% if @prop.errors.any? %>
   <div class="error_display">
     <% @prop.errors.full_messages.each do |message| %>

--- a/app/views/props/_form.html.erb
+++ b/app/views/props/_form.html.erb
@@ -1,0 +1,24 @@
+<%= render "form" %>
+<% if @prop.errors.any? %>
+  <div class="error_display">
+    <% @prop.errors.full_messages.each do |message| %>
+      <ul>
+        <li><%= message %></li>
+      </ul>
+    <% end %>
+  </div>
+<% end %>
+
+<%= form_with(model:@prop, local:true) do |form| %>
+  <p><%= form.label :name %></p>
+  <p><%= form.text_field :name %></p>
+  <p><%= form.label :address %></p>
+  <p><%= form.text_field :address %></p>
+  <p><%= form.label :rent %></p>
+  <p><%= form.text_field :rent %></p>
+  <p><%= form.label :years_old %></p>
+  <p><%= form.text_field :years_old %></p>
+  <p><%= form.label :comment %></p>
+  <p><%= form.text_area :comment %></p>
+  <p><%= form.submit "登録する" %></p>
+<% end %>

--- a/app/views/props/edit.html.erb
+++ b/app/views/props/edit.html.erb
@@ -1,0 +1,4 @@
+<h1>物件編集</h1>
+
+<%= render 'form' %>
+<p><%= link_to "詳細", prop_path(@prop.id) %>|<%= link_to "戻る", props_path %></p>

--- a/app/views/props/index.html.erb
+++ b/app/views/props/index.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% @props.each do |prop| %>
     <tr>
-      <td><%= prop.name %></td><td><%= prop.rent.to_s(:delimited) %>円</td><td><%= prop.address %></td><td><%= prop.years_old %>年</td><td><%= prop.comment %></td><td><%= link_to "詳細", prop_path(prop.id) %></td>
+      <td><%= prop.name %></td><td><%= prop.rent.to_s(:delimited) %>円</td><td><%= prop.address %></td><td><%= prop.years_old %>年</td><td><%= prop.comment %></td><td><%= link_to "詳細", prop_path(prop.id) %></td><td><%= link_to "編集", edit_prop_path(prop.id) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/props/index.html.erb
+++ b/app/views/props/index.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% @props.each do |prop| %>
     <tr>
-      <td><%= prop.name %></td><td><%= prop.rent.to_s(:delimited) %>円</td><td><%= prop.address %></td><td><%= prop.years_old %>年</td><td><%= prop.comment %></td><td><%= link_to "詳細", prop_path(prop.id) %></td><td><%= link_to "編集", edit_prop_path(prop.id) %></td>
+      <td><%= prop.name %></td><td><% if presence_or_not_display(prop.rent) %><%= prop.rent.to_s(:delimited) %>円<% end %></td><td><%= prop.address %></td><td><% if presence_or_not_display(prop.years_old) %><%= prop.years_old %>年<% end %></td><td><%= presence_or_not_display(prop.comment) %></td><td><%= link_to "詳細", prop_path(prop.id) %></td><td><%= link_to "編集", edit_prop_path(prop.id) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/props/index.html.erb
+++ b/app/views/props/index.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% @props.each do |prop| %>
     <tr>
-      <td><%= prop.name %></td><td><%= prop.rent.to_s(:delimited) %>円</td><td><%= prop.address %></td><td><%= prop.years_old %>年</td><td><%= prop.comment %></td>
+      <td><%= prop.name %></td><td><%= prop.rent.to_s(:delimited) %>円</td><td><%= prop.address %></td><td><%= prop.years_old %>年</td><td><%= prop.comment %></td><td><%= link_to "詳細", prop_path(prop.id) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/props/new.html.erb
+++ b/app/views/props/new.html.erb
@@ -1,3 +1,4 @@
 <h1>物件登録</h1>
+<%= render 'form' %>
 <p><%= link_to "一覧に戻る", props_path %></p>
 <p><%= link_to "戻る", props_path %></p>

--- a/app/views/props/new.html.erb
+++ b/app/views/props/new.html.erb
@@ -1,26 +1,3 @@
 <h1>物件登録</h1>
 <p><%= link_to "一覧に戻る", props_path %></p>
-<% if @prop.errors.any? %>
-  <div class="error_display">
-    <% @prop.errors.full_messages.each do |message| %>
-      <ul>
-        <li><%= message %></li>
-      </ul>
-    <% end %>
-  </div>
-<% end %>
-
-<%= form_with(model:@prop, local:true) do |form| %>
-  <p><%= form.label :name %></p>
-  <p><%= form.text_field :name %></p>
-  <p><%= form.label :address %></p>
-  <p><%= form.text_field :address %></p>
-  <p><%= form.label :rent %></p>
-  <p><%= form.text_field :rent %></p>
-  <p><%= form.label :years_old %></p>
-  <p><%= form.text_field :years_old %></p>
-  <p><%= form.label :comment %></p>
-  <p><%= form.text_area :comment %></p>
-  <p><%= form.submit "登録する" %></p>
-  <p><%= link_to "戻る", props_path %></p>
-<% end %>
+<p><%= link_to "戻る", props_path %></p>

--- a/app/views/props/show.html.erb
+++ b/app/views/props/show.html.erb
@@ -6,5 +6,5 @@
 <p><%= @prop.comment %></p>
 
 <div class="bottom_link">
-  <%= link_to "戻る", props_path %>
+  <%= link_to "編集", edit_prop_path(@prop.id) %> | <%= link_to "戻る", props_path %>
 </div>

--- a/app/views/props/show.html.erb
+++ b/app/views/props/show.html.erb
@@ -1,0 +1,10 @@
+<p><span class="show_label">物件名:</span><%= @prop.name %></p>
+<p><span class="show_label">賃料:</span><%= @prop.rent.to_s(:delimited) %>円</p>
+<p><span class="show_label">住所:</span><%= @prop.address %></p>
+<p><span class="show_label">築年数:</span><%= @prop.years_old %></p>
+<p><span class="show_label">備考:</span></p>
+<p><%= @prop.comment %></p>
+
+<div class="bottom_link">
+  <%= link_to "戻る", props_path %>
+</div>

--- a/app/views/props/show.html.erb
+++ b/app/views/props/show.html.erb
@@ -1,9 +1,9 @@
 <p><span class="show_label">物件名:</span><%= @prop.name %></p>
-<p><span class="show_label">賃料:</span><%= @prop.rent.to_s(:delimited) %>円</p>
+<p><span class="show_label">賃料:</span><% if presence_or_not_display(@prop.rent) %><%= @prop.rent.to_s(:delimited) %>円<% end %></p>
 <p><span class="show_label">住所:</span><%= @prop.address %></p>
-<p><span class="show_label">築年数:</span><%= @prop.years_old %></p>
+<p><span class="show_label">築年数:</span><% if presence_or_not_display(@prop.years_old) %><%= @prop.years_old %>年<% end %></p>
 <p><span class="show_label">備考:</span></p>
-<p><%= @prop.comment %></p>
+<p><%= presence_or_not_display(@prop.comment) %></p>
 
 <div class="bottom_link">
   <%= link_to "編集", edit_prop_path(@prop.id) %> | <%= link_to "戻る", props_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  resources :props, only: [:index, :new, :create,:show]
+  resources :props, only: [:index, :new, :create,:show,:edit,:update]
   root to: "props#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  resources :props, only: [:index, :new, :create]
+  resources :props, only: [:index, :new, :create,:show]
   root to: "props#index"
 end


### PR DESCRIPTION
#5 

- props/show,edit,updateアクションを定義
- 上記アクションの為のルーティングを設定
- showビューを作成
- 物件登録用のフォームをパーシャルに切り出し、流用してeditビューを作成
- indexビューに詳細表示用のリンクを追加
- indexビューとshowビューに物件編集用のリンクを追加
