### PR TITLE
【Fixed】物件削除機能の実装

### DIFF
--- a/app/assets/stylesheets/props.scss
+++ b/app/assets/stylesheets/props.scss
@@ -1,3 +1,7 @@
+a {
+  text-decoration: none;
+}
+
 .properties td {
   padding: 10px;
 }
@@ -9,4 +13,17 @@
 .show_label {
   font-weight: bold;
   padding-right: 20px;
+}
+
+.delete_button {
+  padding: 0;
+  color: blue;
+  font-size: 1rem;
+  background-color: rgb(249, 107, 137);
+  background: transparent;
+  border: 0;
+}
+
+.delete_button:hover {
+  cursor: pointer;
 }

--- a/app/controllers/props_controller.rb
+++ b/app/controllers/props_controller.rb
@@ -1,4 +1,6 @@
 class PropsController < ApplicationController
+before_action :set_prop, only: [:show,:edit,:update,:destroy]
+
   def index
     @props = Prop.all
   end
@@ -18,15 +20,12 @@ class PropsController < ApplicationController
   end
 
   def show
-    @prop = Prop.find(params[:id])
   end
 
   def edit
-    @prop = Prop.find(params[:id])
   end
 
   def update
-    @prop = Prop.find(params[:id])
     if @prop.update(prop_params)
       redirect_to props_path
       flash[:notice] = "物件を編集しました。"
@@ -35,9 +34,19 @@ class PropsController < ApplicationController
     end
   end
 
+  def destroy
+    @prop.destroy
+    redirect_to props_path
+    flash[:notice] = "物件を削除しました。"
+  end
+
   private
 
   def prop_params
     params.require(:prop).permit(:name,:address,:rent,:years_old,:comment)
+  end
+
+  def set_prop
+    @prop = Prop.find(params[:id])
   end
 end

--- a/app/views/props/index.html.erb
+++ b/app/views/props/index.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% @props.each do |prop| %>
     <tr>
-      <td><%= prop.name %></td><td><% if presence_or_not_display(prop.rent) %><%= prop.rent.to_s(:delimited) %>円<% end %></td><td><%= prop.address %></td><td><% if presence_or_not_display(prop.years_old) %><%= prop.years_old %>年<% end %></td><td><%= presence_or_not_display(prop.comment) %></td><td><%= link_to "詳細", prop_path(prop.id) %></td><td><%= link_to "編集", edit_prop_path(prop.id) %></td><td><%= button_to "削除", prop_path(prop.id),method: :delete, data: {confirm: "本当に削除しますか？"} %></td>
+      <td><%= prop.name %></td><td><% if presence_or_not_display(prop.rent) %><%= prop.rent.to_s(:delimited) %>円<% end %></td><td><%= prop.address %></td><td><% if presence_or_not_display(prop.years_old) %><%= prop.years_old %>年<% end %></td><td><%= presence_or_not_display(prop.comment) %></td><td><%= link_to "詳細", prop_path(prop.id) %></td><td><%= link_to "編集", edit_prop_path(prop.id) %></td><td><%= button_to "削除", prop_path(prop.id),method: :delete, data: {confirm: "本当に削除しますか？"}, class:"delete_button" %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/props/index.html.erb
+++ b/app/views/props/index.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% @props.each do |prop| %>
     <tr>
-      <td><%= prop.name %></td><td><% if presence_or_not_display(prop.rent) %><%= prop.rent.to_s(:delimited) %>円<% end %></td><td><%= prop.address %></td><td><% if presence_or_not_display(prop.years_old) %><%= prop.years_old %>年<% end %></td><td><%= presence_or_not_display(prop.comment) %></td><td><%= link_to "詳細", prop_path(prop.id) %></td><td><%= link_to "編集", edit_prop_path(prop.id) %></td>
+      <td><%= prop.name %></td><td><% if presence_or_not_display(prop.rent) %><%= prop.rent.to_s(:delimited) %>円<% end %></td><td><%= prop.address %></td><td><% if presence_or_not_display(prop.years_old) %><%= prop.years_old %>年<% end %></td><td><%= presence_or_not_display(prop.comment) %></td><td><%= link_to "詳細", prop_path(prop.id) %></td><td><%= link_to "編集", edit_prop_path(prop.id) %></td><td><%= button_to "削除", prop_path(prop.id),method: :delete, data: {confirm: "本当に削除しますか？"} %></td>
     </tr>
   <% end %>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  resources :props, only: [:index, :new, :create,:show,:edit,:update]
+  resources :props, only: [:index, :new, :create,:show,:edit,:update, :destroy]
   root to: "props#index"
 end


### PR DESCRIPTION
#7 

- props/destroyアクションの定義
- props/destroyアクション用のルーティング
- コントローラー内の表記整理
- indexビューに削除ボタンを追加し、そこから物件を削除出来る（実行時確認が出る）